### PR TITLE
Fix Klarna for sw prior to 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## NEXT PATCH RELEASE
+
+### en
+
+* Fixes a bug that caused Klarna not to work under Shopware versions prior to 5.5. 
+
+### de
+
+* Behebt einen Fehler, der dazu führte, das Klarna unter Shopware-Versionen vor 5.5 nicht funktionierte. 
+
+
 ## 5.3.0
 
 ### en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### en
 
-* Fixes a bug that caused Klarna not to work under Shopware versions prior to 5.5. 
+* Fixes a bug that prevented Klarna payments from working on Shopware version older than 5.5.0. 
 
 ### de
 
-* Behebt einen Fehler, der dazu führte, das Klarna unter Shopware-Versionen vor 5.5 nicht funktionierte. 
+* Behebt einen Fehler, der unter Shopware-Versionen älter als 5.5.0 dazu führte, dass Zahlungen mittels Klarna nicht funktionierten.
 
 
 ## 5.3.0

--- a/Components/PaymentMethods/Klarna.php
+++ b/Components/PaymentMethods/Klarna.php
@@ -25,7 +25,7 @@ class Klarna extends AbstractStripePaymentMethod
                 'description' => $item['articlename'],
                 'quantity' => $item['quantity'],
                 'currency' => $currencyCode,
-                'amount' => round($item['amountNumeric'] * 100),
+                'amount' => round($item['priceNumeric'] * $item['quantity'] * 100),
             ];
         }, $basket['content']);
 


### PR DESCRIPTION
Currently to determine the amount of a position we use `amountNumeric` which is not available prior to Shopware 5.5 because of this the items all have the amount of 0 which does not add up to the total amount which is correct this results in an error when trying to create the stripe source.

To fix this and make it compatible with all supported version we need to calculate the complete amount of a position with the price of a single item time the quantity. In this case we use `priceNumeric` and `quantity` which gives us the same result as `amountNumeric` in Showare versions were it is present.

Fixes #73