### PR TITLE
Fix payments not possible via digital wallets when customer address is in a country other than the stripe account 

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -343,21 +343,14 @@ class Shopware_Plugins_Frontend_StripePayment_Bootstrap extends Shopware_Compone
                     'name' => 'stripeAccountCountryIso',
                 ]);
 
-                if (!$configValue) {
+                if (Util::getConfigValue('stripeAccountCountryIso')) {
                     $defaultShopLocale = $this->get('db')->fetchOne(
                         'SELECT locale FROM s_core_locales l JOIN s_core_shops s ON s.locale_id = l.id WHERE s.default = 1'
                     );
 
-                    // Create new config element using a fake form, since all elements must belong to a form
-                    $configValue = new Element('string', 'stripeAccountCountryIso', []);
-                    /** @var Form $fakeForm */
-                    $fakeForm = $this->get('models')->getPartialReference('Shopware\\Models\\Config\\Form', 0);
-                    $configValue->setForm($fakeForm);
-                    $this->get('models')->persist($configValue);
+                    $countryISO = explode('_', $defaultShopLocale)[1];
 
-                    // Save the value
-                    $configValue->setValue($defaultShopLocale);
-                    $this->get('models')->flush($configValue);
+                    Util::setConfigValue('stripeAccountCountryIso', 'string', $countryISO);
                 }
                 // Next release
 
@@ -380,7 +373,6 @@ class Shopware_Plugins_Frontend_StripePayment_Bootstrap extends Shopware_Compone
                 'allowMotoTransactions',
                 'allowSavingCreditCard',
                 'showPaymentProviderLogos',
-                'stripeAccountCountryIso',
             ]
         );
 
@@ -410,14 +402,7 @@ class Shopware_Plugins_Frontend_StripePayment_Bootstrap extends Shopware_Compone
             's_user_attributes'
         ]);
 
-        $configValue = $this->get('models')->getRepository('Shopware\\Models\\Config\\Element')->findOneBy([
-            'name' => 'stripeAccountCountryIso',
-        ]);
-
-        if ($configValue) {
-            $this->get('models')->remove($configValue);
-            $this->get('models')->flush($configValue);
-        }
+        Util::removeConfigValue('stripeAccountCountryIso');
 
         return true;
     }

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -10,7 +10,6 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 }
 
 use Shopware\Models\Config\Element;
-use Shopware\Models\Config\Form;
 use Shopware\Models\Payment\Payment as PaymentMethod;
 use Shopware\Plugins\StripePayment\Classes\ConfigFormInstallationHelper;
 use Shopware\Plugins\StripePayment\Classes\SmartyPlugins;
@@ -340,9 +339,11 @@ class Shopware_Plugins_Frontend_StripePayment_Bootstrap extends Shopware_Compone
             case '5.3.4':
                 if (!Util::getConfigValue('stripeAccountCountryIso')) {
                     $defaultShopLocale = $this->get('db')->fetchOne(
-                        'SELECT locale FROM s_core_locales l JOIN s_core_shops s ON s.locale_id = l.id WHERE s.default = 1'
+                        'SELECT locale.locale
+                        FROM s_core_locales locale
+                        JOIN s_core_shops shop ON shop.locale_id = locale.id
+                        WHERE shop.default = 1'
                     );
-
                     $countryISO = explode('_', $defaultShopLocale)[1];
 
                     Util::setConfigValue('stripeAccountCountryIso', 'string', $countryISO);

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -338,12 +338,7 @@ class Shopware_Plugins_Frontend_StripePayment_Bootstrap extends Shopware_Compone
             case '5.3.3':
                 // Nothing to do
             case '5.3.4':
-                // Check for a saved default grid label template
-                $configValue = $this->get('models')->getRepository('Shopware\\Models\\Config\\Element')->findOneBy([
-                    'name' => 'stripeAccountCountryIso',
-                ]);
-
-                if (Util::getConfigValue('stripeAccountCountryIso')) {
+                if (!Util::getConfigValue('stripeAccountCountryIso')) {
                     $defaultShopLocale = $this->get('db')->fetchOne(
                         'SELECT locale FROM s_core_locales l JOIN s_core_shops s ON s.locale_id = l.id WHERE s.default = 1'
                     );

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -379,6 +379,7 @@ class Shopware_Plugins_Frontend_StripePayment_Bootstrap extends Shopware_Compone
                 'backend',
                 'frontend',
                 'config',
+                'proxy',
             ],
         ];
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### en
 
-* Fixes a bug that prevented payments with digital wallets (Apple Pay, Google Pay, ...) if the country of the customer and the country of the configured Stripe account differed.
+* Fixes a bug that prevented payments with digital wallets (Apple Pay, Google Pay, ...) if the country of the customer and the country of the configured Stripe account differ.
     * For this purpose, the country of the Stripe account holder is automatically loaded from the account. For this, the plugin configuration must be saved again.
 
 ### de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ### en
 
 * Fixes a bug that prevented payments with digital wallets (Apple Pay, Google Pay, ...) if the country of the customer and the country of the configured Stripe account differed.
+    * For this purpose, the country of the Stripe account holder is automatically loaded from the account. For this, the plugin configuration must be saved again.
 
 ### de
 
 * Behebt einen Fehler, der dazu führte, dass Zahlungen mit Digital Wallets (Apple Pay, Google Pay, ...) nicht funktionierten, wenn sich das Land des Kunden und das des hinterlegten Stripe-Accounts unterscheiden.
+    * Das Land des Stripe Accountinhabers wird hierfür automatisch aus dem Account geladen. Hierfür muss die Pluginkonfiguration neu gespeichert werden.
 
 
 ## 5.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## NEXT PATCH RELEASE
+
+### en
+
+* Fixes a bug that prevented payments with digital wallets (Apple Pay, Google Pay, ...) if the country of the customer and the country of the configured Stripe account differed.
+
+### de
+
+* Behebt einen Fehler, der dazu führte, dass Zahlungen mit Digital Wallets (Apple Pay, Google Pay, ...) nicht funktionierten, wenn sich das Land des Kunden und das des hinterlegten Stripe-Accounts unterscheiden.
+
+
 ## 5.3.4
 
 ### en

--- a/Subscriber/Backend/ConfigSubscriber.php
+++ b/Subscriber/Backend/ConfigSubscriber.php
@@ -26,7 +26,7 @@ class ConfigSubscriber implements SubscriberInterface
     }
 
     /**
-     * Handle the retriving of the stripe account country and saving it to a hidden config value
+     * Handle the retrieving of the stripe account country and saving it to a hidden config value
      *
      * @param \Enlight_Hook_HookArgs $args
      */
@@ -34,17 +34,15 @@ class ConfigSubscriber implements SubscriberInterface
     {
         $subject = $args->getSubject();
         $data = $subject->Request()->getParam('elements');
-
         if ($data[0]['name'] !== 'stripeSecretKey') {
             return;
         }
 
-        $secretKey  = Util::stripeSecretKey();
-
+        $secretKey = Util::stripeSecretKey();
         if ($secretKey === '') {
             return;
         }
 
-        Util::setConfigValue('stripeAccountCountryIso', 'string', Util::getAccount()->country);
+        Util::setConfigValue('stripeAccountCountryIso', 'string', Util::getStripeAccount()->country);
     }
 }

--- a/Subscriber/Backend/ConfigSubscriber.php
+++ b/Subscriber/Backend/ConfigSubscriber.php
@@ -26,7 +26,7 @@ class ConfigSubscriber implements SubscriberInterface
     }
 
     /**
-     * Handle the creation and editing of new coupon document types
+     * Handle the retriving of the stripe account country and saving it to a hidden config value
      *
      * @param \Enlight_Hook_HookArgs $args
      */
@@ -39,24 +39,6 @@ class ConfigSubscriber implements SubscriberInterface
             return;
         }
 
-        $entityManager = Shopware()->Container()->get('models');
-
-        // Check for a saved default grid label template
-        $configValue = $entityManager->getRepository('Shopware\\Models\\Config\\Element')->findOneBy([
-            'name' => 'stripeAccountCountryIso',
-        ]);
-
-        if (!$configValue) {
-            // Create new config element using a fake form, since all elements must belong to a form
-            $configValue = new Element('string', 'stripeAccountCountryIso', []);
-            /** @var Form $fakeForm */
-            $fakeForm = $entityManager->getPartialReference('Shopware\\Models\\Config\\Form', 0);
-            $configValue->setForm($fakeForm);
-            $entityManager->persist($configValue);
-        }
-
-        // Save the value
-        $configValue->setValue(Util::getAccount()->country);
-        $entityManager->flush($configValue);
+        Util::setConfigValue('stripeAccountCountryIso', 'string', Util::getAccount()->country);
     }
 }

--- a/Subscriber/Backend/ConfigSubscriber.php
+++ b/Subscriber/Backend/ConfigSubscriber.php
@@ -1,0 +1,62 @@
+<?php
+// Copyright (c) Pickware GmbH. All rights reserved.
+// This file is part of software that is released under a proprietary license.
+// You must not copy, modify, distribute, make publicly available, or execute
+// its contents or parts thereof without express permission by the copyright
+// holder, unless otherwise permitted by law.
+
+namespace Shopware\Plugins\StripePayment\Subscriber\Backend;
+
+use Enlight\Event\SubscriberInterface;
+use Shopware\Components\Model\ModelManager;
+use Shopware\Models\Config\Element;
+use Shopware\Models\Config\Form;
+use Shopware\Plugins\StripePayment\Util;
+
+class ConfigSubscriber implements SubscriberInterface
+{
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            'Shopware_Controllers_Backend_Config::saveFormAction::after' => 'onAfterSaveFormAction',
+        ];
+    }
+
+    /**
+     * Handle the creation and editing of new coupon document types
+     *
+     * @param \Enlight_Hook_HookArgs $args
+     */
+    public function onAfterSaveFormAction(\Enlight_Hook_HookArgs $args)
+    {
+        $subject = $args->getSubject();
+        $data = $subject->Request()->getParam('elements');
+
+        if ($data[0]['name'] !== 'stripeSecretKey' && $data[0]['value'] === '') {
+            return;
+        }
+
+        $entityManager = Shopware()->Container()->get('models');
+
+        // Check for a saved default grid label template
+        $configValue = $entityManager->getRepository('Shopware\\Models\\Config\\Element')->findOneBy([
+            'name' => 'stripeAccountCountryIso',
+        ]);
+
+        if (!$configValue) {
+            // Create new config element using a fake form, since all elements must belong to a form
+            $configValue = new Element('string', 'stripeAccountCountryIso', []);
+            /** @var Form $fakeForm */
+            $fakeForm = $entityManager->getPartialReference('Shopware\\Models\\Config\\Form', 0);
+            $configValue->setForm($fakeForm);
+            $entityManager->persist($configValue);
+        }
+
+        // Save the value
+        $configValue->setValue(Util::getAccount()->country);
+        $entityManager->flush($configValue);
+    }
+}

--- a/Subscriber/Backend/ConfigSubscriber.php
+++ b/Subscriber/Backend/ConfigSubscriber.php
@@ -8,9 +8,6 @@
 namespace Shopware\Plugins\StripePayment\Subscriber\Backend;
 
 use Enlight\Event\SubscriberInterface;
-use Shopware\Components\Model\ModelManager;
-use Shopware\Models\Config\Element;
-use Shopware\Models\Config\Form;
 use Shopware\Plugins\StripePayment\Util;
 
 class ConfigSubscriber implements SubscriberInterface
@@ -33,8 +30,8 @@ class ConfigSubscriber implements SubscriberInterface
     public function onAfterSaveFormAction(\Enlight_Hook_HookArgs $args)
     {
         $subject = $args->getSubject();
-        $data = $subject->Request()->getParam('elements');
-        if ($data[0]['name'] !== 'stripeSecretKey') {
+        $isStripePaymentConfig = $subject->Request()->getParam('name') === 'StripePayment';
+        if (!$isStripePaymentConfig) {
             return;
         }
 

--- a/Subscriber/Backend/ConfigSubscriber.php
+++ b/Subscriber/Backend/ConfigSubscriber.php
@@ -35,7 +35,13 @@ class ConfigSubscriber implements SubscriberInterface
         $subject = $args->getSubject();
         $data = $subject->Request()->getParam('elements');
 
-        if ($data[0]['name'] !== 'stripeSecretKey' && $data[0]['value'] === '') {
+        if ($data[0]['name'] !== 'stripeSecretKey') {
+            return;
+        }
+
+        $secretKey  = Util::stripeSecretKey();
+
+        if ($secretKey === '') {
             return;
         }
 

--- a/Subscriber/Frontend/Checkout.php
+++ b/Subscriber/Frontend/Checkout.php
@@ -66,6 +66,9 @@ class Checkout implements SubscriberInterface
             $stripeViewParams['publicKey'] = Util::stripePublicKey();
             $stripeViewParams['allowSavingCreditCard'] = Shopware()->Container()->get('plugins')->get('Frontend')->get('StripePayment')->Config()->get('allowSavingCreditCard', true);
             $stripeViewParams['showPaymentProviderLogos'] = Shopware()->Container()->get('plugins')->get('Frontend')->get('StripePayment')->Config()->get('showPaymentProviderLogos', true);
+            $stripeViewParams['stripeAccountCountryIso'] = Shopware()->Container()->get('models')->getRepository('Shopware\\Models\\Config\\Element')->findOneBy([
+                'name' => 'stripeAccountCountryIso',
+            ])->getValue();
 
             // Check for an error
             if ($stripeSession->paymentError) {

--- a/Subscriber/Frontend/Checkout.php
+++ b/Subscriber/Frontend/Checkout.php
@@ -66,9 +66,7 @@ class Checkout implements SubscriberInterface
             $stripeViewParams['publicKey'] = Util::stripePublicKey();
             $stripeViewParams['allowSavingCreditCard'] = Shopware()->Container()->get('plugins')->get('Frontend')->get('StripePayment')->Config()->get('allowSavingCreditCard', true);
             $stripeViewParams['showPaymentProviderLogos'] = Shopware()->Container()->get('plugins')->get('Frontend')->get('StripePayment')->Config()->get('showPaymentProviderLogos', true);
-            $stripeViewParams['stripeAccountCountryIso'] = Shopware()->Container()->get('models')->getRepository('Shopware\\Models\\Config\\Element')->findOneBy([
-                'name' => 'stripeAccountCountryIso',
-            ])->getValue();
+            $stripeViewParams['stripeAccountCountryIso'] = Util::getConfigValue('stripeAccountCountryIso');
 
             // Check for an error
             if ($stripeSession->paymentError) {

--- a/Util.php
+++ b/Util.php
@@ -268,6 +268,13 @@ class Util
         return trim($billingAddress->getFirstName() . ' ' . $billingAddress->getLastName());
     }
 
+    public static function getAccount()
+    {
+        self::initStripeAPI();
+
+        return Stripe\Account::retrieve();
+    }
+
     /**
      * Decodes the requests's JSON body and tries to retrieve the Stripe event whose
      * ID is contained in the request.

--- a/Util.php
+++ b/Util.php
@@ -270,6 +270,9 @@ class Util
         return trim($billingAddress->getFirstName() . ' ' . $billingAddress->getLastName());
     }
 
+    /**
+     * @return Stripe\Account The stripe account for the used secret key
+     */
     public static function getAccount()
     {
         self::initStripeAPI();

--- a/Util.php
+++ b/Util.php
@@ -273,7 +273,7 @@ class Util
     /**
      * @return Stripe\Account The stripe account for the used secret key
      */
-    public static function getAccount()
+    public static function getStripeAccount()
     {
         self::initStripeAPI();
 

--- a/Util.php
+++ b/Util.php
@@ -8,6 +8,8 @@
 namespace Shopware\Plugins\StripePayment;
 
 use Shopware\Models\Attribute\Customer as CustomerAttribute;
+use Shopware\Models\Config\Element;
+use Shopware\Models\Config\Form;
 use Shopware\Models\Customer\Customer;
 use Stripe;
 
@@ -314,5 +316,65 @@ class Util
     public static function resetStripeSession()
     {
         Shopware()->Container()->get('session')->stripePayment = new \ArrayObject([], \ArrayObject::STD_PROP_LIST);
+    }
+
+    /**
+     * Set a hidden config value.
+     *
+     * @param string $name
+     * @param string $type
+     * @param mixed $value
+     */
+    public static function setConfigValue($name, $type, $value)
+    {
+        // Check for a saved default grid label template
+        $configValue = Shopware()->Models()->getRepository('Shopware\\Models\\Config\\Element')->findOneBy([
+            'name' => $name,
+        ]);
+
+        if (!$configValue) {
+            // Create new config element using a fake form, since all elements must belong to a form
+            $configValue = new Element($type, $name, []);
+            /** @var Form $fakeForm */
+            $fakeForm = Shopware()->Models()->getPartialReference('Shopware\\Models\\Config\\Form', 0);
+            $configValue->setForm($fakeForm);
+            Shopware()->Models()->persist($configValue);
+        }
+
+        // Save the value
+        $configValue->setValue($value);
+        Shopware()->Models()->flush($configValue);
+    }
+
+    /**
+     * Returns the current hidden config value.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public static function getConfigValue($name)
+    {
+        $configValue = Shopware()->Models()->getRepository('Shopware\\Models\\Config\\Element')->findOneBy([
+            'name' => $name,
+        ]);
+
+        return ($configValue) ? $configValue->getValue() : null;
+    }
+
+    /**
+     * Clears a config value.
+     *
+     * @param string $name
+     */
+    public static function removeConfigValue($name)
+    {
+        $configValue = Shopware()->Models()->getRepository('Shopware\\Models\\Config\\Element')->findOneBy([
+            'name' => $name,
+        ]);
+
+        if ($configValue) {
+            Shopware()->Models()->remove($configValue);
+            Shopware()->Models()->flush($configValue);
+        }
     }
 }

--- a/Views/frontend/checkout/confirm.tpl
+++ b/Views/frontend/checkout/confirm.tpl
@@ -81,7 +81,7 @@
                 stripePaymentSnippets.error.notAvailable = stripePaymentSnippets.error.notAvailable.replace('[0]', paymentMethodName);
 
                 var stripePaymentConfig = {
-                    countryCode: '{$sUserData.additional.country.countryiso|escape:"javascript"}',
+                    countryCode: '{$stripePayment.stripeAccountCountryIso|escape:"javascript"}',
                     currencyCode: '{$stripePayment.currency|escape:"javascript"}',
                     statementDescriptor: '{$stripePayment.digitalWalletsStatementDescriptor|escape:"javascript"}',
                     amount: '{$sAmount|escape:"javascript"}',


### PR DESCRIPTION
**Summary**

Currently for StripePayments we use the country code of the customer which is wrong since it needs to be the country code which is set in the stripe account.
When updating the plugin we use the last 2 digits of the ISO Code from the default shops localization as a default stripe account country code. This will be updated to the country code of the stripe account if the stripe config gets saved with a valid secret key. 

Closes #93 