### PR TITLE
Clear one time credit cards from session after failed checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 * Fixes a bug that prevented payments with digital wallets (Apple Pay, Google Pay, ...) if the country of the customer and the country of the configured Stripe account differ.
     * For this purpose, the country of the Stripe account holder is automatically loaded from the account. For this, the plugin configuration must be saved again.
-* Fixes a bug that caused unsaved credit cards to continue to display when an order was completed incorrectly.
+* Fixes a bug that caused unsaved credit cards to continue to be displayed after a failed order completion.
 
 ### de
 
 * Behebt einen Fehler, der dazu führte, dass Zahlungen mit Digital Wallets (Apple Pay, Google Pay, ...) nicht funktionierten, wenn sich das Land des Kunden und das des hinterlegten Stripe-Accounts unterscheiden.
     * Das Land des Stripe Accountinhabers wird hierfür automatisch aus dem Account geladen. Hierfür muss die Pluginkonfiguration neu gespeichert werden.
-* Behebt einen Fehler, der dazu führte, dass nicht gespeicherte Kreditkarten bei einem fehlerhaften Bestellabschluss weiterhin angezeigt wurden.
+* Behebt einen Fehler, der dazu führte, dass nicht gespeicherte Kreditkarten nach einem fehlgeschlagenen Bestellabschluss weiterhin angezeigt wurden.
 
 
 ## 5.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     * Das Land des Stripe Accountinhabers wird hierfür automatisch aus dem Account geladen. Hierfür muss die Pluginkonfiguration neu gespeichert werden.
 * Behebt einen Fehler, der dazu führte, dass nicht gespeicherte Kreditkarten bei einem fehlerhaften Bestellabschluss weiterhin angezeigt wurden.
 
+
 ## 5.3.4
 
 ### en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 * Fixes a bug that prevented payments with digital wallets (Apple Pay, Google Pay, ...) if the country of the customer and the country of the configured Stripe account differ.
     * For this purpose, the country of the Stripe account holder is automatically loaded from the account. For this, the plugin configuration must be saved again.
+* Fixes a bug that caused unsaved credit cards to continue to display when an order was completed incorrectly.
 
 ### de
 
 * Behebt einen Fehler, der dazu führte, dass Zahlungen mit Digital Wallets (Apple Pay, Google Pay, ...) nicht funktionierten, wenn sich das Land des Kunden und das des hinterlegten Stripe-Accounts unterscheiden.
     * Das Land des Stripe Accountinhabers wird hierfür automatisch aus dem Account geladen. Hierfür muss die Pluginkonfiguration neu gespeichert werden.
-
+* Behebt einen Fehler, der dazu führte, dass nicht gespeicherte Kreditkarten bei einem fehlerhaften Bestellabschluss weiterhin angezeigt wurden.
 
 ## 5.3.4
 

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -48,7 +48,6 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         if ($paymentIntent->status === 'requires_action') {
             if (!$paymentIntent->next_action || $paymentIntent->next_action->type !== 'redirect_to_url') {
                 $message = $this->getStripePaymentMethod()->getSnippet('payment_error/message/redirect/failed');
-                Util::removeNotSavedCardFromSession();
                 $this->cancelCheckout($message);
 
                 return;
@@ -74,7 +73,6 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
                     ]
                 );
                 $message = $this->getStripePaymentMethod()->getErrorMessage($e);
-                Util::removeNotSavedCardFromSession();
                 $this->cancelCheckout($message);
 
                 return;
@@ -84,7 +82,6 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         } else {
             // Unable to process payment
             $message = $this->getStripePaymentMethod()->getSnippet('payment_error/message/source_declined');
-            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
         }
     }
@@ -103,7 +100,6 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         $clientSecret = $this->Request()->getParam('payment_intent_client_secret');
         if (!$clientSecret || $clientSecret !== Util::getStripeSession()->redirectClientSecret) {
             $message = $this->getStripePaymentMethod()->getSnippet('payment_error/message/redirect/internal_error');
-            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
 
             return;
@@ -114,7 +110,6 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         $paymentIntent = Stripe\PaymentIntent::retrieve($paymentIntentId);
         if (!$paymentIntent) {
             $message = $this->getStripePaymentMethod()->getSnippet('payment_error/message/redirect/internal_error');
-            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
 
             return;
@@ -124,7 +119,6 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
             if ($paymentIntent->last_payment_error && $paymentIntent->last_payment_error->code) {
                 $message = ($this->getStripePaymentMethod()->getSnippet('error/' . $paymentIntent->last_payment_error->code)) ?: $message;
             }
-            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
 
             return;
@@ -135,7 +129,6 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
             $order = $this->saveOrderWithPaymentIntent($paymentIntent);
         } catch (Exception $e) {
             $message = $this->getStripePaymentMethod()->getErrorMessage($e);
-            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
 
             return;

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -48,6 +48,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         if ($paymentIntent->status === 'requires_action') {
             if (!$paymentIntent->next_action || $paymentIntent->next_action->type !== 'redirect_to_url') {
                 $message = $this->getStripePaymentMethod()->getSnippet('payment_error/message/redirect/failed');
+                Util::removeNotSavedCardFromSession();
                 $this->cancelCheckout($message);
 
                 return;
@@ -73,6 +74,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
                     ]
                 );
                 $message = $this->getStripePaymentMethod()->getErrorMessage($e);
+                Util::removeNotSavedCardFromSession();
                 $this->cancelCheckout($message);
 
                 return;
@@ -82,6 +84,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         } else {
             // Unable to process payment
             $message = $this->getStripePaymentMethod()->getSnippet('payment_error/message/source_declined');
+            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
         }
     }

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -100,6 +100,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         $clientSecret = $this->Request()->getParam('payment_intent_client_secret');
         if (!$clientSecret || $clientSecret !== Util::getStripeSession()->redirectClientSecret) {
             $message = $this->getStripePaymentMethod()->getSnippet('payment_error/message/redirect/internal_error');
+            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
 
             return;
@@ -110,6 +111,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         $paymentIntent = Stripe\PaymentIntent::retrieve($paymentIntentId);
         if (!$paymentIntent) {
             $message = $this->getStripePaymentMethod()->getSnippet('payment_error/message/redirect/internal_error');
+            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
 
             return;
@@ -119,6 +121,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
             if ($paymentIntent->last_payment_error && $paymentIntent->last_payment_error->code) {
                 $message = ($this->getStripePaymentMethod()->getSnippet('error/' . $paymentIntent->last_payment_error->code)) ?: $message;
             }
+            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
 
             return;
@@ -129,6 +132,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
             $order = $this->saveOrderWithPaymentIntent($paymentIntent);
         } catch (Exception $e) {
             $message = $this->getStripePaymentMethod()->getErrorMessage($e);
+            Util::removeNotSavedCardFromSession();
             $this->cancelCheckout($message);
 
             return;

--- a/Controllers/StripeCheckout.php
+++ b/Controllers/StripeCheckout.php
@@ -71,6 +71,7 @@ trait StripeCheckout
             $prefix = $this->get('snippets')->getNamespace('frontend/plugins/payment/stripe_payment/base')->get('payment_error/message/charge_failed');
             Util::getStripeSession()->paymentError = $prefix . ' ' . $errorMessage;
         }
+        Util::removeUnsavedSelectedCardFromSession();
         $this->redirect([
             'controller' => 'checkout',
             'action' => 'index',

--- a/Util.php
+++ b/Util.php
@@ -324,14 +324,14 @@ class Util
     /**
      * Removes Cards that are not saved for future checkouts from the session.
      */
-    public static function removeNotSavedCardFromSession()
+    public static function removeUnsavedSelectedCardFromSession()
     {
         $session = Shopware()->Container()->get('session')->stripePayment;
 
-        $saveCardForFutureCheckouts = array_key_exists('saveCardForFutureCheckouts', $session);
+        $hasSaveCardForFutureCheckouts = array_key_exists('saveCardForFutureCheckouts', $session);
 
-        if ($saveCardForFutureCheckouts && !$session->saveCardForFutureCheckouts) {
-            $session->selectedCard = [];
+        if ($hasSaveCardForFutureCheckouts && !$session->saveCardForFutureCheckouts) {
+            unset($session->selectedCard);
             unset($session->saveCardForFutureCheckouts);
         }
     }

--- a/Util.php
+++ b/Util.php
@@ -322,6 +322,21 @@ class Util
     }
 
     /**
+     * Removes Cards that are not saved for future checkouts from the session.
+     */
+    public static function removeNotSavedCardFromSession()
+    {
+        $session = Shopware()->Container()->get('session')->stripePayment;
+
+        $saveCardForFutureCheckouts = array_key_exists('saveCardForFutureCheckouts', $session);
+
+        if ($saveCardForFutureCheckouts && !$session->saveCardForFutureCheckouts) {
+            $session->selectedCard = [];
+            unset($session->saveCardForFutureCheckouts);
+        }
+    }
+
+    /**
      * Set a hidden config value.
      *
      * @param string $name


### PR DESCRIPTION
Currently when a payment with a credit card fails we redirect to the checkout with the last selected card still selected.
This is a problem if the last card was a one time use card since it will not work anymore.

This PR changes this by removing one time credit cards from the session after a failed checkout.

Fixes #91 